### PR TITLE
Win app fix from ChatGPT Agent

### DIFF
--- a/src/windows/uninstall.ps1
+++ b/src/windows/uninstall.ps1
@@ -20,18 +20,34 @@ if ($task) {
     $InstallDir = $DefaultInstallDir
 }
 
+# Remove scheduled task if exists
 if (Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue) {
     Stop-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
     Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false
     Write-Host "Scheduled task removed."
 }
 
-# Kill any orphaned processes
-Get-CimInstance Win32_Process | Where-Object { $_.CommandLine -like "*eth-wifi-auto.ps1*" } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
+# Kill any running helper processes
+Get-CimInstance Win32_Process | Where-Object { $_.CommandLine -like "*eth-wifi-auto.ps1*" } |
+    ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
 
 if (Test-Path $InstallDir) {
-    Remove-Item -Path $InstallDir -Recurse -Force
-    Write-Host "Installation directory removed."
+    Write-Host "Removing installation directory..."
+
+    # Create a temporary script that will delete the installation directory after this script exits.
+    $tempRemovePath = Join-Path ([System.IO.Path]::GetTempPath()) "ethwifi_remove.ps1"
+    $removeScript = @"
+Start-Sleep -Milliseconds 500
+try {
+    Remove-Item -Path `"$InstallDir`" -Recurse -Force -ErrorAction SilentlyContinue
+} catch {}
+try {
+    Remove-Item -Path `"$tempRemovePath`" -Force -ErrorAction SilentlyContinue
+} catch {}
+"@
+    $removeScript | Out-File -FilePath $tempRemovePath -Encoding UTF8 -Force
+    # Launch the temp script in a new background PowerShell process
+    Start-Process powershell.exe -ArgumentList "-NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -File `"$tempRemovePath`"" -WindowStyle Hidden
 }
 
 Write-Host "✅ Uninstalled completely."


### PR DESCRIPTION
This pull request introduces improvements to the detection and handling of network adapters in the Windows PowerShell scripts, enhances Wi-Fi radio control for more robust switching, and makes the uninstall process more reliable. The most important changes are grouped below:

**Network Adapter Detection and User Feedback:**

* Refactored the network adapter detection logic in `install-template.ps1` to list all Ethernet and Wi-Fi adapters for user selection, improving clarity and robustness over the previous prioritized detection method. The script now displays all detected adapters and shows which will be used by default.

**Wi-Fi Radio Control Enhancements:**

* Added a new `Set-WifiRadioState` function in `switcher.ps1` to toggle the Wi-Fi radio using the Windows.Devices.Radios API, providing a more reliable way to enable or disable Wi-Fi and gracefully falling back to adapter-level commands if the API is unavailable.
* Updated the Wi-Fi enable/disable logic in `Check-And-Switch` to use the new radio API before falling back to `Enable-NetAdapter`/`Disable-NetAdapter`, ensuring Wi-Fi is managed at both the radio and adapter level for better compatibility. [[1]](diffhunk://#diff-b8a362e005361605de947610126764802e1ecad5c144e79cb7898929efc1813cL89-R115) [[2]](diffhunk://#diff-b8a362e005361605de947610126764802e1ecad5c144e79cb7898929efc1813cL108-R143)

**Uninstall Process Improvements:**

* Improved the uninstall script (`uninstall.ps1`) to remove the installation directory more reliably by launching a temporary background script that deletes the directory after the main script exits, avoiding issues with locked files. Also clarified process cleanup messaging.